### PR TITLE
error handling: stacktrace for library + panic for CLI usage

### DIFF
--- a/ciphers/caesar.go
+++ b/ciphers/caesar.go
@@ -12,7 +12,7 @@ type Caesar struct {
 	Decoder
 }
 
-func (c *Caesar) encodeChar(b rune) rune {
+func (c *Caesar) encodeChar(b rune) (rune, error) {
 	var encoded rune
 	var err error
 
@@ -26,13 +26,13 @@ func (c *Caesar) encodeChar(b rune) rune {
 	}
 
 	if err != nil {
-		panic("error encoding character")
+		return 0, err
 	}
 
-	return encoded
+	return encoded, nil
 }
 
-func (c *Caesar) decodeChar(b rune) rune {
+func (c *Caesar) decodeChar(b rune) (rune, error) {
 	var decoded rune
 	var err error
 
@@ -46,26 +46,34 @@ func (c *Caesar) decodeChar(b rune) rune {
 	}
 
 	if err != nil {
-		panic("error decoding character")
+		return 0, err
 	}
 
-	return decoded
+	return decoded, nil
 }
 
-func (c *Caesar) Encode(s string) string {
+func (c *Caesar) Encode(s string) (string, error) {
 	var runes []rune
 	for _, curr := range s {
-		runes = append(runes, c.encodeChar(curr))
+		enc, err := c.encodeChar(curr)
+		if err != nil {
+			return "", err
+		}
+		runes = append(runes, enc)
 	}
-	return string(runes)
+	return string(runes), nil
 }
 
-func (c *Caesar) Decode(s string) string {
+func (c *Caesar) Decode(s string) (string, error) {
 	var runes []rune
 	for _, curr := range s {
-		runes = append(runes, c.decodeChar(curr))
+		dec, err := c.decodeChar(curr)
+		if err != nil {
+			return "", err
+		}
+		runes = append(runes, dec)
 	}
-	return string(runes)
+	return string(runes), nil
 }
 
 func NewCaesar(offset int) *Caesar {

--- a/ciphers/caesar_test.go
+++ b/ciphers/caesar_test.go
@@ -67,9 +67,12 @@ func (suite *CaesarTest) TestEncoding() {
 	for i, offset := range suite.caesarEncode.offsets {
 		cs := NewCaesar(offset)
 
+		enc, err := cs.Encode(suite.caesarEncode.inputs[i])
+		suite.Nil(err)
+
 		suite.Equal(
 			suite.caesarEncode.expectedOutputs[i],
-			cs.Encode(suite.caesarEncode.inputs[i]),
+			enc,
 		)
 	}
 }
@@ -78,9 +81,12 @@ func (suite *CaesarTest) TestDecoding() {
 	for i, offset := range suite.caesarDecode.offsets {
 		cs := NewCaesar(offset)
 
+		dec, err := cs.Decode(suite.caesarDecode.inputs[i])
+		suite.Nil(err)
+
 		suite.Equal(
 			suite.caesarDecode.expectedOutputs[i],
-			cs.Decode(suite.caesarDecode.inputs[i]),
+			dec,
 		)
 	}
 }

--- a/ciphers/encoder.go
+++ b/ciphers/encoder.go
@@ -1,9 +1,9 @@
 package ciphers
 
 type Encoder interface {
-	Encode(string) string
+	Encode(string) (string, error)
 }
 
 type Decoder interface {
-	Decode(string) string
+	Decode(string) (string, error)
 }

--- a/ciphers/playfair_test.go
+++ b/ciphers/playfair_test.go
@@ -98,10 +98,11 @@ func (suite *PlayfairTest) TestEncode() {
 	for _, cs := range suite.encodeCases {
 		key, input := cs.key, cs.input
 		playfair := NewPlayfair(key)
-		output := playfair.Encode(input)
+		enc, err := playfair.Encode(input)
 
+		suite.Nil(err)
 		suite.Equal(
-			cs.output, output,
+			cs.output, enc,
 		)
 		suite.Equal(
 			cs.digrams, playfair.digrams,
@@ -113,10 +114,11 @@ func (suite *PlayfairTest) TestDecode() {
 	for _, cs := range suite.decodeCases {
 		key, input := cs.key, cs.input
 		playfair := NewPlayfair(key)
-		output := playfair.Decode(input)
+		dec, err := playfair.Decode(input)
 
+		suite.Nil(err)
 		suite.Equal(
-			cs.output, output,
+			cs.output, dec,
 		)
 
 		suite.Equal(

--- a/ciphers/vigenere.go
+++ b/ciphers/vigenere.go
@@ -28,7 +28,7 @@ func (v *Vigenere) offset(c rune) int {
 	}
 }
 
-func (v *Vigenere) encodeChar(c rune, keyRune rune) rune {
+func (v *Vigenere) encodeChar(c rune, keyRune rune) (rune, error) {
 	var encoded rune
 	var err error
 
@@ -43,13 +43,13 @@ func (v *Vigenere) encodeChar(c rune, keyRune rune) rune {
 	}
 
 	if err != nil {
-		panic("error encoding byte")
+		return 0, err
 	}
 
-	return encoded
+	return encoded, nil
 }
 
-func (v *Vigenere) decodeChar(c rune, keyRune rune) rune {
+func (v *Vigenere) decodeChar(c rune, keyRune rune) (rune, error) {
 	var decoded rune
 	var err error
 
@@ -64,35 +64,44 @@ func (v *Vigenere) decodeChar(c rune, keyRune rune) rune {
 	}
 
 	if err != nil {
-		panic("error decoding character")
+		return 0, err
 	}
 
-	return decoded
+	return decoded, nil
 }
 
-func (v *Vigenere) Encode(s string) string {
+func (v *Vigenere) Encode(s string) (string, error) {
 	var runes []rune
 	for i, curr := range s {
 		// key repeats until it's the same length as string
 		// to encrypt. e.g. input string `attackatdawn` and key
 		// `LEMON` gives padded key `LEMONLEMONLE`.
 		keyRune := []rune(v.key)[i%len(v.key)]
-		nextByte := v.encodeChar(curr, keyRune)
+		nextByte, err := v.encodeChar(curr, keyRune)
+		if err != nil {
+			return "", err
+		}
 		runes = append(runes, nextByte)
 	}
-	return string(runes)
+
+	return string(runes), nil
 }
 
-func (v *Vigenere) Decode(s string) string {
+func (v *Vigenere) Decode(s string) (string, error) {
 	var runes []rune
 	for i, curr := range s {
 		// key repeats until it's the same length as string
 		// to encrypt. e.g. input string `attackatdawn` and key
 		// `LEMON` gives padded key `LEMONLEMONLE`.
 		keyRune := []rune(v.key)[i%len(v.key)]
-		runes = append(runes, v.decodeChar(curr, keyRune))
+		nextByte, err := v.decodeChar(curr, keyRune)
+		if err != nil {
+			return "", err
+		}
+		runes = append(runes, nextByte)
 	}
-	return string(runes)
+
+	return string(runes), nil
 }
 
 func NewVigenere(key string) *Vigenere {

--- a/ciphers/vigenere_test.go
+++ b/ciphers/vigenere_test.go
@@ -65,9 +65,12 @@ func (suite *VigenereTest) TestEncoding() {
 	for i, key := range suite.vigenereEncode.keys {
 		vg := NewVigenere(key)
 
+		enc, err := vg.Encode(suite.vigenereEncode.inputs[i])
+
+		suite.Nil(err)
 		suite.Equal(
 			suite.vigenereEncode.expectedOutputs[i],
-			vg.Encode(suite.vigenereEncode.inputs[i]),
+			enc,
 		)
 	}
 }
@@ -76,9 +79,12 @@ func (suite *VigenereTest) TestDecoding() {
 	for i, key := range suite.vigenereDecode.keys {
 		vg := NewVigenere(key)
 
+		dec, err := vg.Decode(suite.vigenereDecode.inputs[i])
+
+		suite.Nil(err)
 		suite.Equal(
 			suite.vigenereDecode.expectedOutputs[i],
-			vg.Decode(suite.vigenereDecode.inputs[i]),
+			dec,
 		)
 	}
 }

--- a/cmd/cipher/main.go
+++ b/cmd/cipher/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"ciphers/ciphers"
+	"errors"
 	"fmt"
 	"github.com/urfave/cli/v2"
 	"log"
@@ -23,7 +24,10 @@ func vigenere() *cli.Command {
 					str := cCtx.Args().Get(0)
 					key := cCtx.Args().Get(1)
 					vig := ciphers.NewVigenere(key)
-					encoded := vig.Encode(str)
+					encoded, err := vig.Encode(str)
+					if err != nil {
+						return errors.New("could not encode: " + err.Error())
+					}
 
 					fmt.Println(encoded)
 					return nil
@@ -37,7 +41,10 @@ func vigenere() *cli.Command {
 					str := cCtx.Args().Get(0)
 					key := cCtx.Args().Get(1)
 					vig := ciphers.NewVigenere(key)
-					decoded := vig.Decode(str)
+					decoded, err := vig.Decode(str)
+					if err != nil {
+						return errors.New("could not decode: " + err.Error())
+					}
 
 					fmt.Println(decoded)
 					return nil
@@ -65,7 +72,11 @@ func caesar() *cli.Command {
 					}
 
 					caesar := ciphers.NewCaesar(offset)
-					encoded := caesar.Encode(str)
+					encoded, err := caesar.Encode(str)
+					if err != nil {
+						return errors.New("could not encode: " + err.Error())
+					}
+
 					fmt.Println(encoded)
 					return nil
 				},
@@ -82,7 +93,11 @@ func caesar() *cli.Command {
 					}
 
 					caesar := ciphers.NewCaesar(offset)
-					decoded := caesar.Decode(str)
+					decoded, err := caesar.Decode(str)
+					if err != nil {
+						return errors.New("could not decode: " + err.Error())
+					}
+
 					fmt.Println(decoded)
 					return nil
 				},
@@ -105,7 +120,10 @@ func playfair() *cli.Command {
 					str := cCtx.Args().Get(0)
 					key := cCtx.Args().Get(1)
 					pf := ciphers.NewPlayfair(key)
-					encoded := pf.Encode(str)
+					encoded, err := pf.Encode(str)
+					if err != nil {
+						return errors.New("could not encode: " + err.Error())
+					}
 
 					fmt.Println(encoded)
 					return nil
@@ -119,7 +137,10 @@ func playfair() *cli.Command {
 					str := cCtx.Args().Get(0)
 					key := cCtx.Args().Get(1)
 					pf := ciphers.NewPlayfair(key)
-					decoded := pf.Decode(str)
+					decoded, err := pf.Decode(str)
+					if err != nil {
+						return errors.New("could not decode: " + err.Error())
+					}
 
 					fmt.Println(decoded)
 					return nil


### PR DESCRIPTION
Improve error handling. Namely:

* Update signature of `Encoder` and `Decoder` interface functions to `(string, error)`
* Handle these errors in the CLI app, returning the error from the `Action` func.

This will allow the usage of this package in both modes - library & CLI with consistent and logical erroring.